### PR TITLE
FT: creating the timeout is too large error test and fixing the invalid json error test.

### DIFF
--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -79,3 +79,16 @@ class CreateCheckTestCase(BaseTestCase):
 
     ### Test for the assignment of channels
     ### Test for the 'timeout is too small' and 'timeout is too large' errors
+    def test_timeout_too_large(self):
+        r = self.post({
+            "api_key": "abc",
+            "name": "Foo",
+            "tags": "bar,baz",
+            "timeout": 700000,
+            "grace": 60
+        }    
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.json()["error"],"timeout is too large" )
+
+    

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -62,10 +62,14 @@ class CreateCheckTestCase(BaseTestCase):
         self.assertEqual(r.json()["error"], "wrong api_key")
 
     def test_it_handles_invalid_json(self):
-        ### Make the post request with invalid json data type
-        r = {'status_code': 400, 'error': "could not parse request body"} ### This is just a placeholder variable
-        self.assertEqual(r['status_code'], 400)
-        self.assertEqual(r["error"], "could not parse request body")
+        ### Make the post
+        #  request with invalid json data type
+        response = self.client.post(self.URL,{
+            "api_key": "abc",
+            "name": "Foo"
+            })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "could not parse request body")
 
     def test_it_rejects_wrong_api_key(self):
         responce = self.post({"api_key": "wrong"},
@@ -82,7 +86,7 @@ class CreateCheckTestCase(BaseTestCase):
     def test_it_rejects_non_string_name(self):
         r = self.post({
             "api_key": "abc",
-             "name": False,
+             'name': 30,
              "tags": "cronjob",
              "timeout": 60000,
              "grace": 120,
@@ -137,4 +141,3 @@ class CreateCheckTestCase(BaseTestCase):
         self.assertEqual(r.status_code, 400)
         self.assertEqual(r.json()["error"],"timeout is too large" )
 
-    

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -80,8 +80,15 @@ class CreateCheckTestCase(BaseTestCase):
         self.assertEqual(responce.json()["error"], "timeout is not a number")
 
     def test_it_rejects_non_string_name(self):
-        self.post({"api_key": "abc", "name": False},
-                  expected_error="name is not a string")
+        r = self.post({
+            "api_key": "abc",
+             "name": False,
+             "tags": "cronjob",
+             "timeout": 60000,
+             "grace": 120,
+            })
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.json()["error"], "name is not a string")
 
     def test_it_can_assign_check_to_all_channels(self):
         ### Test for the assignment of channels


### PR DESCRIPTION
#### Problem
- There was no testing if the app returned an appropriate error if the user typed in a timeout that's too large.
-The testing of the error that should be returned when an inappropriate json object is sent was not complete.

#### Solution
- For both the tests, it was important that the test uses the post method defined in the 'test_create_check.py' file to create the 'POST' request to the "/api/v1/checks/" url.Then assert if the error messages and status codes are the same as what's expected.