### PR TITLE
[CH:] Update README badges to point to develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # healthchecks
- [![CircleCI](https://circleci.com/gh/andela/hc-june-bunnies/tree/jk%2Fadd-continuous-integration.svg?style=svg)](https://circleci.com/gh/andela/hc-june-bunnies/tree/jk%2Fadd-continuous-integration) [![Coverage Status](https://coveralls.io/repos/github/andela/hc-june-bunnies/badge.svg?branch=jk%2Fadd-continuous-integration)](https://coveralls.io/github/andela/hc-june-bunnies?branch=jk%2Fadd-continuous-integration)
+[![CircleCI](https://circleci.com/gh/andela/hc-june-bunnies.svg?style=svg)](https://circleci.com/gh/andela/hc-june-bunnies)       [![Coverage Status](https://coveralls.io/repos/github/andela/hc-june-bunnies/badge.svg?branch=develop)](https://coveralls.io/github/andela/hc-june-bunnies?branch=develop)
 
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 


### PR DESCRIPTION
#### Problem
- The badges in `README` in `develop` branch were pointing to the branch `jk/add-continuous-integration` and thus the coverage been shown are not updating

#### Solution
- Changed the badges to point to the right branch

#### Screenshots
##### New badges
![New badge shows coverage as 90%](https://user-images.githubusercontent.com/28805113/42677992-3370d062-8686-11e8-9410-9a4f6b587cf0.png)


[PT Card](https://www.pivotaltracker.com/story/show/159028359)