### PR TITLE
[FT:] Add dashboard tab for unresolved checks.

### DIFF
--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -41,7 +41,7 @@ def my_checks(request):
     else:
         q = Check.objects.filter(user=request.team.user).order_by("created")
         checks =list(q)
-    
+    down_checks =[]
     counter = Counter()
     down_tags, grace_tags = set(), set()
     for check in checks:
@@ -53,6 +53,7 @@ def my_checks(request):
             counter[tag] += 1
 
             if status == "down":
+                down_checks.append(check)
                 down_tags.add(tag)
             elif check.in_grace_period():
                 grace_tags.add(tag)
@@ -63,6 +64,7 @@ def my_checks(request):
         "now": timezone.now(),
         "tags": counter.most_common(),
         "down_tags": down_tags,
+        "down_checks": down_checks,
         "grace_tags": grace_tags,
         "ping_endpoint": settings.PING_ENDPOINT
     }

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -1,143 +1,292 @@
 {% load hc_extras humanize %}
-<table id="checks-table" class="table hidden-xs">
-    <tr>
-        <th></th>
-        <th class="th-name">Name</th>
-        <th>Ping URL</th>
-        <th class="th-period">
-            Period <br />
-            <span class="checks-subline">Grace</span><br/>
-            Nag Interval
-        </th>
-        <th>Last Ping</th>
-        <th>Nag Status</th>
-        <th></th>
-    </tr>
-    {% for check in checks %}
-    <tr class="checks-row">
-        <td class="indicator-cell">
-            {% if check.get_status == "new" %}
-                <span class="status icon-up new"
-                    data-toggle="tooltip" title="New. Has never received a ping."></span>
-            {% elif check.get_status == "paused" %}
-                <span class="status icon-paused"
-                    data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
-            {% elif check.in_grace_period %}
-                <span class="status icon-grace"></span>
-            {% elif check.get_status == "up" %}
-                <span class="status icon-up"></span>
-            {% elif check.get_status == "down" %}
-                <span class="status icon-down"></span>
-            {% endif %}
-        </td>
-        <td class="name-cell">
-            <div data-name="{{ check.name }}"
-                    data-tags="{{ check.tags }}"
-                    data-url="{% url 'hc-update-name' check.code %}"
-                    class="my-checks-name {% if not check.name %}unnamed{% endif %}">
-                <div>{{ check.name|default:"unnamed" }}</div>
-                {% for tag in check.tags_list %}
-                <span class="label label-tag">{{ tag }}</span>
-                {% endfor %}
-            </div>
-        </td>
-        <td class="url-cell">
-            <span class="my-checks-url">
-                <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
-            </span>
-            <button
-                class="copy-link hidden-sm"
-                data-clipboard-text="{{ check.url }}">
-                copy
-            </button>
-        </td>
-        <td class="timeout-cell">
-            <span
-                data-url="{% url 'hc-update-timeout' check.code %}"
-                data-timeout="{{ check.timeout.total_seconds }}"
-                data-grace="{{ check.grace.total_seconds }}"
-                data-nag="{{ check.new_nag_after.total_seconds }}"
-                class="timeout-grace">
-                {{ check.timeout|hc_duration }}
-                <br />
-                <span class="checks-subline">
-                {{ check.grace|hc_duration }}
-                </span>
-                <br />
-                <span class="timeout-nag">
-                {{ check.new_nag_after|hc_duration }}
-                </span>
-            </span>
-        </td>
-        <td>
-        {% if check.last_ping %}
-            <span
-                data-toggle="tooltip"
-                title="{{ check.last_ping|date:'N j, Y, P e' }}">
-                {{ check.last_ping|naturaltime }}
-            </span>
-        {% else %}
-            Never
-        {% endif %}
-        </td>
-        <td>
-            {% if check.nag_after > check.alert_after and check.nag_status == True %}
-                <button
-                    data-nag="{{ check.nag_status }}"
-                    data-url="{% url 'hc-update-nag' check.code %}"
-                    class="btn btn-danger update-nag">NAGGING!</button>
-            {% elif check.nag_status == True %}
-                <button
-                    data-nag="{{ check.nag_status }}"
-                    data-url="{% url 'hc-update-nag' check.code %}"
-                    class="btn btn-info update-nag">Nag On</button>
-            {% else %}
-                <button
-                    data-nag="{{ check.nag_status }}"
-                    data-url="{% url 'hc-update-nag' check.code %}"
-                    class="btn btn-default update-nag">Nag Off</button>
-            {% endif %}  
-        </td>
-        <td>
-            <div class="check-menu dropdown">
-                <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                <span class="icon-settings" aria-hidden="true"></span>
-                </button>
-                <ul class="dropdown-menu">
-                    <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
-                        <a class="pause-check"
-                           href="#"
-                           data-url="{% url 'hc-pause' check.code %}">
-                           Pause Monitoring
-                        </a>
-                    </li>
-                    <li role="separator" class="divider"></li>
-                    <li>
-                        <a href="{% url 'hc-log' check.code %}">
-                            Log
-                        </a>
-                    </li>
-                    <li>
-                        <a
-                            href="#"
-                            class="usage-examples"
-                            data-url="{{ check.url }}"
-                            data-email="{{ check.email }}">
-                            Usage Examples
-                        </a>
-                    </li>
-                    <li role="separator" class="divider"></li>
-                    <li>
-                        <a href="#" class="check-menu-remove"
-                            data-name="{{ check.name_then_code }}"
-                            data-url="{% url 'hc-remove-check' check.code %}">
-                            Remove
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </td>
-    </tr>
-    {% endfor %}
+<br>
+<ul class="nav nav-tabs hidden-xs">
+    <li role="presentation" class="active">
+        <a href="#allchecks" aria-controls="allchecks" role="tab" data-toggle="tab">All Checks</a>
+    </li>
+    <li role="presentation">
+        <a href="#unresolved" aria-controls="unresolved" role="tab" data-toggle="tab">Unresolved Checks </a>
+    </li>
+</ul>
+<div class="tab-content hidden-xs">
+    <div role="tabpanel" class="tab-pane active" id="allchecks">
+    <!-- all checks tab -->
+        <table id="checks-table" class="table hidden-xs">
+            <tr>
+                <th></th>
+                <th class="th-name">Name</th>
+                <th>Ping URL</th>
+                <th class="th-period">
+                    Period <br />
+                    <span class="checks-subline">Grace</span><br/>
+                    Nag Interval
+                </th>
+                <th>Last Ping</th>
+                <th>Nag Status</th>
+                <th></th>
+            </tr>
+            {% for check in checks %}
+            <tr class="checks-row">
+                <td class="indicator-cell">
+                    {% if check.get_status == "new" %}
+                        <span class="status icon-up new"
+                            data-toggle="tooltip" title="New. Has never received a ping."></span>
+                    {% elif check.get_status == "paused" %}
+                        <span class="status icon-paused"
+                            data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
+                    {% elif check.in_grace_period %}
+                        <span class="status icon-grace"></span>
+                    {% elif check.get_status == "up" %}
+                        <span class="status icon-up"></span>
+                    {% elif check.get_status == "down" %}
+                        <span class="status icon-down"></span>
+                    {% endif %}
+                </td>
+                <td class="name-cell">
+                    <div data-name="{{ check.name }}"
+                            data-tags="{{ check.tags }}"
+                            data-url="{% url 'hc-update-name' check.code %}"
+                            class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                        <div>{{ check.name|default:"unnamed" }}</div>
+                        {% for tag in check.tags_list %}
+                        <span class="label label-tag">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                </td>
+                <td class="url-cell">
+                    <span class="my-checks-url">
+                        <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
+                    </span>
+                    <button
+                        class="copy-link hidden-sm"
+                        data-clipboard-text="{{ check.url }}">
+                        copy
+                    </button>
+                </td>
+                <td class="timeout-cell">
+                    <span
+                        data-url="{% url 'hc-update-timeout' check.code %}"
+                        data-timeout="{{ check.timeout.total_seconds }}"
+                        data-grace="{{ check.grace.total_seconds }}"
+                        data-nag="{{ check.new_nag_after.total_seconds }}"
+                        class="timeout-grace">
+                        {{ check.timeout|hc_duration }}
+                        <br />
+                        <span class="checks-subline">
+                        {{ check.grace|hc_duration }}
+                        </span>
+                        <br />
+                        <span class="timeout-nag">
+                        {{ check.new_nag_after|hc_duration }}
+                        </span>
+                    </span>
+                </td>
+                <td>
+                {% if check.last_ping %}
+                    <span
+                        data-toggle="tooltip"
+                        title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                        {{ check.last_ping|naturaltime }}
+                    </span>
+                {% else %}
+                    Never
+                {% endif %}
+                </td>
+                <td>
+                    {% if check.nag_after > check.alert_after and check.nag_status == True %}
+                        <button
+                            data-nag="{{ check.nag_status }}"
+                            data-url="{% url 'hc-update-nag' check.code %}"
+                            class="btn btn-danger update-nag">NAGGING!</button>
+                    {% elif check.nag_status == True %}
+                        <button
+                            data-nag="{{ check.nag_status }}"
+                            data-url="{% url 'hc-update-nag' check.code %}"
+                            class="btn btn-info update-nag">Nag On</button>
+                    {% else %}
+                        <button
+                            data-nag="{{ check.nag_status }}"
+                            data-url="{% url 'hc-update-nag' check.code %}"
+                            class="btn btn-default update-nag">Nag Off</button>
+                    {% endif %}  
+                </td>
+                <td>
+                    <div class="check-menu dropdown">
+                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                        <span class="icon-settings" aria-hidden="true"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
+                                <a class="pause-check"
+                                    href="#"
+                                    data-url="{% url 'hc-pause' check.code %}">
+                                    Pause Monitoring
+                                </a>
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="{% url 'hc-log' check.code %}">
+                                    Log
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    href="#"
+                                    class="usage-examples"
+                                    data-url="{{ check.url }}"
+                                    data-email="{{ check.email }}">
+                                    Usage Examples
+                                </a>
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="#" class="check-menu-remove"
+                                    data-name="{{ check.name_then_code }}"
+                                    data-url="{% url 'hc-remove-check' check.code %}">
+                                    Remove
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+            
+        </table>
+    <!-- /Eof all checks tab-->
+    </div>
+    <div role="tabpanel" class="tab-pane" id="unresolved">
+        <!-- unresolved tab -->
+        <table id="checks-table" class="table hidden-xs">
+            <tr>
+                <th></th>
+                <th class="th-name">Name</th>
+                <th>Ping URL</th>
+                <th class="th-period">
+                    Period <br />
+                    <span class="checks-subline">Grace</span><br/>
+                    Nag Interval
+                </th>
+                <th>Last Ping</th>
+                <th>Nag Status</th>
+                <th></th>
+            </tr>
+            {% for check in down_checks %}
+            <tr class="checks-row">
+                <td class="indicator-cell">
+                    <span class="status icon-down"></span>
+                </td>
+                <td class="name-cell">
+                    <div data-name="{{ check.name }}"
+                            data-tags="{{ check.tags }}"
+                            data-url="{% url 'hc-update-name' check.code %}"
+                            class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                        <div>{{ check.name|default:"unnamed" }}</div>
+                        {% for tag in check.tags_list %}
+                        <span class="label label-tag">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                </td>
+                <td class="url-cell">
+                    <span class="my-checks-url">
+                        <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
+                    </span>
+                    <button
+                        class="copy-link hidden-sm"
+                        data-clipboard-text="{{ check.url }}">
+                        copy
+                    </button>
+                </td>
+                <td class="timeout-cell">
+                    <span
+                        data-url="{% url 'hc-update-timeout' check.code %}"
+                        data-timeout="{{ check.timeout.total_seconds }}"
+                        data-grace="{{ check.grace.total_seconds }}"
+                        data-nag="{{ check.new_nag_after.total_seconds }}"
+                        class="timeout-grace">
+                        {{ check.timeout|hc_duration }}
+                        <br />
+                        <span class="checks-subline">
+                        {{ check.grace|hc_duration }}
+                        </span>
+                        <br />
+                        <span class="timeout-nag">
+                        {{ check.new_nag_after|hc_duration }}
+                        </span>
+                    </span>
+                </td>
+                <td>
+                {% if check.last_ping %}
+                    <span
+                        data-toggle="tooltip"
+                        title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                        {{ check.last_ping|naturaltime }}
+                    </span>
+                {% else %}
+                    Never
+                {% endif %}
+                </td>
+                <td>
+                    {% if check.nag_after > check.alert_after and check.nag_status == True %}
+                        <button
+                            data-nag="{{ check.nag_status }}"
+                            data-url="{% url 'hc-update-nag' check.code %}"
+                            class="btn btn-danger update-nag">NAGGING!</button>
+                    {% elif check.nag_status == True %}
+                        <button
+                            data-nag="{{ check.nag_status }}"
+                            data-url="{% url 'hc-update-nag' check.code %}"
+                            class="btn btn-info update-nag">Nag On</button>
+                    {% else %}
+                        <button
+                            data-nag="{{ check.nag_status }}"
+                            data-url="{% url 'hc-update-nag' check.code %}"
+                            class="btn btn-default update-nag">Nag Off</button>
+                    {% endif %}  
+                </td>
+                <td>
+                    <div class="check-menu dropdown">
+                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                        <span class="icon-settings" aria-hidden="true"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
+                                <a class="pause-check"
+                                    href="#"
+                                    data-url="{% url 'hc-pause' check.code %}">
+                                    Pause Monitoring
+                                </a>
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="{% url 'hc-log' check.code %}">
+                                    Log
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    href="#"
+                                    class="usage-examples"
+                                    data-url="{{ check.url }}"
+                                    data-email="{{ check.email }}">
+                                    Usage Examples
+                                </a>
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="#" class="check-menu-remove"
+                                    data-name="{{ check.name_then_code }}"
+                                    data-url="{% url 'hc-remove-check' check.code %}">
+                                    Remove
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+            
+        </table>
+    </div>
+</div>
 
-</table>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -1,112 +1,226 @@
 {% load hc_extras humanize %}
+<br>
+<ul class="nav nav-tabs visible-xs">
+        <li role="presentation" class="active">
+            <a href="#allchecks-mobile" aria-controls="allchecks-mobile" role="tab" data-toggle="tab">All Checks</a>
+        </li>
+        <li role="presentation">
+            <a href="#unresolved-mobile" aria-controls="unresolved-mobile" role="tab" data-toggle="tab">Unresolved Checks </a>
+        </li>
+    </ul>
+    <div class="tab-content visible-xs">
+        <div role="tabpanel" class="tab-pane active" id="allchecks-mobile">
+            <ul id="checks-list" class="visible-xs">
+                {% for check in checks %}
+                <li>
+                    <h2>
+                        <span class="{% if not check.name %}unnamed{% endif %}">
+                            {{ check.name|default:"unnamed" }}
+                        </span>
 
-<ul id="checks-list" class="visible-xs">
-    {% for check in checks %}
-    <li>
-        <h2>
-            <span class="{% if not check.name %}unnamed{% endif %}">
-                {{ check.name|default:"unnamed" }}
-            </span>
+                        <code>{{ check.code }}</code>
+                    </h2>
 
-            <code>{{ check.code }}</code>
-        </h2>
+                    <a
+                        href="#"
+                        class="btn remove-link check-menu-remove"
+                        data-name="{{ check.name_then_code }}"
+                        data-url="{% url 'hc-remove-check' check.code %}">
+                        <span class="icon-close"></span>
+                    </a>
 
-        <a
-            href="#"
-            class="btn remove-link check-menu-remove"
-            data-name="{{ check.name_then_code }}"
-            data-url="{% url 'hc-remove-check' check.code %}">
-            <span class="icon-close"></span>
-        </a>
-
-        <table class="table">
-            <tr>
-                <th>Status</th>
-                <td>
-                    {% if check.get_status == "new" %}
-                        <span class="label label-default">NEW</span>
-                    {% elif check.get_status == "paused" %}
-                        <span class="label label-default">PAUSED</span>
-                    {% elif check.in_grace_period %}
-                        <span class="label label-warning">LATE</span>
-                    {% elif check.get_status == "up" %}
-                        <span class="label label-success">UP</span>
-                    {% elif check.get_status == "down" %}
-                        <span class="label label-danger">DOWN</span>
-                    {% endif %}
-                </td>
-            </tr>
-            {% if check.tags %}
-            <tr>
-                <th>Tags</th>
-                <td>
-                    {% for tag in check.tags_list %}
-                    <span class="label label-tag">{{ tag }}</span>
-                    {% endfor %}
-                </td>
-            </tr>
-            {% endif %}
-            <tr>
-                <th>Period</th>
-                <td>{{ check.timeout|hc_duration }}</td>
-            </tr>
-            <tr>
-                <th>Grace Time</th>
-                <td>{{ check.grace|hc_duration }}</td>
-            </tr>
-            <tr>
-                <th>Last Ping</th>
-                <td>
-                    {% if check.last_ping %}
-                        {{ check.last_ping|naturaltime }}
-                    {% else %}
-                        Never
-                    {% endif %}
-                </td>
-            </tr>
-        </table>
+                    <table class="table">
+                        <tr>
+                            <th>Status</th>
+                            <td>
+                                {% if check.get_status == "new" %}
+                                    <span class="label label-default">NEW</span>
+                                {% elif check.get_status == "paused" %}
+                                    <span class="label label-default">PAUSED</span>
+                                {% elif check.in_grace_period %}
+                                    <span class="label label-warning">LATE</span>
+                                {% elif check.get_status == "up" %}
+                                    <span class="label label-success">UP</span>
+                                {% elif check.get_status == "down" %}
+                                    <span class="label label-danger">DOWN</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if check.tags %}
+                        <tr>
+                            <th>Tags</th>
+                            <td>
+                                {% for tag in check.tags_list %}
+                                <span class="label label-tag">{{ tag }}</span>
+                                {% endfor %}
+                            </td>
+                        </tr>
+                        {% endif %}
+                        <tr>
+                            <th>Period</th>
+                            <td>{{ check.timeout|hc_duration }}</td>
+                        </tr>
+                        <tr>
+                            <th>Grace Time</th>
+                            <td>{{ check.grace|hc_duration }}</td>
+                        </tr>
+                        <tr>
+                            <th>Last Ping</th>
+                            <td>
+                                {% if check.last_ping %}
+                                    {{ check.last_ping|naturaltime }}
+                                {% else %}
+                                    Never
+                                {% endif %}
+                            </td>
+                        </tr>
+                    </table>
 
 
-        <div>
-            <a
-                href="#"
-                data-name="{{ check.name }}"
-                data-tags="{{ check.tags }}"
-                data-url="{% url 'hc-update-name' check.code %}"
-                class="btn btn-default my-checks-name">
-                Rename
-            </a>
+                    <div>
+                        <a
+                            href="#"
+                            data-name="{{ check.name }}"
+                            data-tags="{{ check.tags }}"
+                            data-url="{% url 'hc-update-name' check.code %}"
+                            class="btn btn-default my-checks-name">
+                            Rename
+                        </a>
 
-            <a
-                href="#"
-                data-url="{% url 'hc-update-timeout' check.code %}"
-                data-timeout="{{ check.timeout.total_seconds }}"
-                data-grace="{{ check.grace.total_seconds }}"
-                class="btn btn-default timeout-grace">Change Period</a>
+                        <a
+                            href="#"
+                            data-url="{% url 'hc-update-timeout' check.code %}"
+                            data-timeout="{{ check.timeout.total_seconds }}"
+                            data-grace="{{ check.grace.total_seconds }}"
+                            class="btn btn-default timeout-grace">Change Period</a>
 
-                {% if check.nag_after > check.alert_after and check.nag_status == True %}
-                <a
-                    href="#"
-                    data-nag="{{ check.nag_status }}"
-                    data-url="{% url 'hc-update-nag' check.code %}"
-                    class="btn btn-danger update-nag">NAGGING!</a>
-                {% elif check.nag_status == True %}
-                <a
-                    href="#"
-                    data-nag="{{ check.nag_status }}"
-                    data-url="{% url 'hc-update-nag' check.code %}"
-                    class="btn btn-info update-nag">Nag ON</a>
-                {% else %}
-                <a
-                    href="#"
-                    data-nag="{{ check.nag_status }}"
-                    data-url="{% url 'hc-update-nag' check.code %}"
-                    class="btn btn-default update-nag">Nag OFF</a>
-                {% endif %}
+                            {% if check.nag_after > check.alert_after and check.nag_status == True %}
+                            <a
+                                href="#"
+                                data-nag="{{ check.nag_status }}"
+                                data-url="{% url 'hc-update-nag' check.code %}"
+                                class="btn btn-danger update-nag">NAGGING!</a>
+                            {% elif check.nag_status == True %}
+                            <a
+                                href="#"
+                                data-nag="{{ check.nag_status }}"
+                                data-url="{% url 'hc-update-nag' check.code %}"
+                                class="btn btn-info update-nag">Nag ON</a>
+                            {% else %}
+                            <a
+                                href="#"
+                                data-nag="{{ check.nag_status }}"
+                                data-url="{% url 'hc-update-nag' check.code %}"
+                                class="btn btn-default update-nag">Nag OFF</a>
+                            {% endif %}
 
-            <a href="{% url 'hc-log' check.code %}" class="btn btn-default">Log</a>
+                        <a href="{% url 'hc-log' check.code %}" class="btn btn-default">Log</a>
+                    </div>
+
+                </li>
+                {% endfor %}
+            </ul>
         </div>
-
-    </li>
-    {% endfor %}
-</ul>
+        <div role="tabpanel" class="tab-pane" id="unresolved-mobile">
+            <ul id="checks-list" class="visible-xs">
+                    {% for check in down_checks %}
+                    <li>
+                        <h2>
+                            <span class="{% if not check.name %}unnamed{% endif %}">
+                                {{ check.name|default:"unnamed" }}
+                            </span>
+    
+                            <code>{{ check.code }}</code>
+                        </h2>
+    
+                        <a
+                            href="#"
+                            class="btn remove-link check-menu-remove"
+                            data-name="{{ check.name_then_code }}"
+                            data-url="{% url 'hc-remove-check' check.code %}">
+                            <span class="icon-close"></span>
+                        </a>
+    
+                        <table class="table">
+                            <tr>
+                                <th>Status</th>
+                                <td>
+                                    <span class="label label-danger">DOWN</span>
+                                </td>
+                            </tr>
+                            {% if check.tags %}
+                            <tr>
+                                <th>Tags</th>
+                                <td>
+                                    {% for tag in check.tags_list %}
+                                    <span class="label label-tag">{{ tag }}</span>
+                                    {% endfor %}
+                                </td>
+                            </tr>
+                            {% endif %}
+                            <tr>
+                                <th>Period</th>
+                                <td>{{ check.timeout|hc_duration }}</td>
+                            </tr>
+                            <tr>
+                                <th>Grace Time</th>
+                                <td>{{ check.grace|hc_duration }}</td>
+                            </tr>
+                            <tr>
+                                <th>Last Ping</th>
+                                <td>
+                                    {% if check.last_ping %}
+                                        {{ check.last_ping|naturaltime }}
+                                    {% else %}
+                                        Never
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </table>
+    
+    
+                        <div>
+                            <a
+                                href="#"
+                                data-name="{{ check.name }}"
+                                data-tags="{{ check.tags }}"
+                                data-url="{% url 'hc-update-name' check.code %}"
+                                class="btn btn-default my-checks-name">
+                                Rename
+                            </a>
+    
+                            <a
+                                href="#"
+                                data-url="{% url 'hc-update-timeout' check.code %}"
+                                data-timeout="{{ check.timeout.total_seconds }}"
+                                data-grace="{{ check.grace.total_seconds }}"
+                                class="btn btn-default timeout-grace">Change Period</a>
+    
+                                {% if check.nag_after > check.alert_after and check.nag_status == True %}
+                                <a
+                                    href="#"
+                                    data-nag="{{ check.nag_status }}"
+                                    data-url="{% url 'hc-update-nag' check.code %}"
+                                    class="btn btn-danger update-nag">NAGGING!</a>
+                                {% elif check.nag_status == True %}
+                                <a
+                                    href="#"
+                                    data-nag="{{ check.nag_status }}"
+                                    data-url="{% url 'hc-update-nag' check.code %}"
+                                    class="btn btn-info update-nag">Nag ON</a>
+                                {% else %}
+                                <a
+                                    href="#"
+                                    data-nag="{{ check.nag_status }}"
+                                    data-url="{% url 'hc-update-nag' check.code %}"
+                                    class="btn btn-default update-nag">Nag OFF</a>
+                                {% endif %}
+    
+                            <a href="{% url 'hc-log' check.code %}" class="btn btn-default">Log</a>
+                        </div>
+    
+                    </li>
+                    {% endfor %}
+            </ul>
+        </div>
+    </div>


### PR DESCRIPTION
**Problem**
When a User's job goes down, the user is sent a notification email informing him of the same and no dashoboard to show the same. 

**Solution**
Add a dashboard view of users failed jobs by adding a extra tab `Unresolved Checks`. 

**Screenshots**
**Desktop View**
<img width="1680" alt="screen shot 2018-07-16 at 13 55 20" src="https://user-images.githubusercontent.com/6532136/42755249-12d66796-8900-11e8-850b-ef54886b5846.png">
**Mobile View**
<img width="1248" alt="screen shot 2018-07-16 at 13 55 47" src="https://user-images.githubusercontent.com/6532136/42755406-b1eb19da-8900-11e8-95ea-275e41ff87a9.png">

**Relevant Pivotal Tracker story**
https://www.pivotaltracker.com/story/show/158532877